### PR TITLE
addition of a "nudge" function to make minor size adjustments to a grid array

### DIFF
--- a/nllgrid/NLLGrid.py
+++ b/nllgrid/NLLGrid.py
@@ -1641,11 +1641,13 @@ class NLLGrid(object):
         identical.
         """
         direction = direction.lower()
-        if not direction or direction[0] not in ['e', 'w', 'n', 's', 'u', 'd']:
-            msg = (
-                'Direction must be: "east", "west", "north", "south", "up", '
-                'or "down", or simply: "e", "w", "n", "s", "u", or "d".'
-            )
+        valid_directions = [
+            'east', 'west', 'north', 'south', 'up', 'down',
+            'e', 'w', 'n', 's', 'u', 'd']
+        if direction not in valid_directions:
+            valid_directions = ', '.join(f'"{d}"' for d in valid_directions)
+            msg = f'Invalid direction "{direction}". Must be one of: '
+            msg += valid_directions
             raise ValueError(msg)
         if num_layers == 0:
             return

--- a/nllgrid/NLLGrid.py
+++ b/nllgrid/NLLGrid.py
@@ -1616,7 +1616,7 @@ class NLLGrid(object):
             North-South is axis 1, or the second "Y" element, with north at index 0
             
             Up-Down is axis 2, the third "Z" element, with the surface being index 0
-        num_layers : int, optional
+        num_layers : int, default 1
             Number of layers to add (positive number) or subtract (negative).
             If positive, the layer values are duplicated from the outermost layer.
         

--- a/nllgrid/NLLGrid.py
+++ b/nllgrid/NLLGrid.py
@@ -1706,7 +1706,6 @@ class NLLGrid(object):
 
         if direction not in ['up', 'down', 'u', 'd']:
             self.horizontal_recenter()
-        return
 
     def copy(self):
         """

--- a/nllgrid/NLLGrid.py
+++ b/nllgrid/NLLGrid.py
@@ -1694,7 +1694,7 @@ class NLLGrid(object):
                     layer = layer.reshape(m, n, 1)
                     self.array = np.concatenate((layer, self.array), axis=2)
                     self.z_orig -= self.dz
-            else:  # down
+            elif direction in ['down', 'd']:
                 if polarity < 0:
                     self.array = self.array[:, :, :-1]
                 else:

--- a/nllgrid/NLLGrid.py
+++ b/nllgrid/NLLGrid.py
@@ -1632,7 +1632,7 @@ class NLLGrid(object):
         
         Will add three duplicated 2D layers of p_vel.array[:,0,:] to the "north" side,
         giving the new array a shape of (37, 178, 70). 
-        2D slices p_vel.array[:,174,:] to p_vel.array[:,177,:] will be identical.
+        2D slices p_vel.array[:,0,:] to p_vel.array[:,3,:] will be identical.
         """
         direction = direction.lower()
         if direction[0] not in ['n','s','e','w','u','d']:

--- a/nllgrid/NLLGrid.py
+++ b/nllgrid/NLLGrid.py
@@ -1649,10 +1649,11 @@ class NLLGrid(object):
             msg = f'Invalid direction "{direction}". Must be one of: '
             msg += valid_directions
             raise ValueError(msg)
+        if not isinstance(num_layers, int):
+            raise TypeError('num_layers must be an integer')
         if num_layers == 0:
             return
         polarity = -1 if num_layers < 0 else 1
-        num_layers = int(np.round(num_layers))
 
         for _ in range(abs(num_layers)):
             if direction in ['east', 'e']:

--- a/nllgrid/NLLGrid.py
+++ b/nllgrid/NLLGrid.py
@@ -1672,7 +1672,7 @@ class NLLGrid(object):
                     m, n = layer.shape
                     layer = layer.reshape(1, m, n)
                     self.array = np.concatenate((layer, self.array), axis=0)
-            elif direction in ['south', 's']:
+            elif direction in ['north', 'n']:
                 if polarity < 0:
                     self.array = self.array[:, :-1, :]
                 else:
@@ -1680,7 +1680,7 @@ class NLLGrid(object):
                     m, n = layer.shape
                     layer = layer.reshape(m, 1, n)
                     self.array = np.concatenate((self.array, layer), axis=1)
-            elif direction in ['north', 'n']:
+            elif direction in ['south', 's']:
                 if polarity < 0:
                     self.array = self.array[:, 1:, :]
                 else:

--- a/nllgrid/NLLGrid.py
+++ b/nllgrid/NLLGrid.py
@@ -1601,41 +1601,47 @@ class NLLGrid(object):
 
     def nudge(self, direction, num_layers=1):
         """
-        'Nudge' a grid's dimensions by expanding or contracting in any direction, by
-        any number of 2D layers. The output grid is also recentered.
-        
+        'Nudge' a grid's dimensions by expanding or contracting in any
+        direction, by any number of 2D layers. The output grid is also
+        recentered.
+
         Parameters
         ----------
         direction : char
-            Cardinal direction to adjust, either "east", "west", "north", "south", 
-            as well as "up" or "down" ...or simply u, d, e, w, n, s.
-            
-            West-East is axis 0, or the first "X" element of the array, with east
-            at index -1
-            
-            North-South is axis 1, or the second "Y" element, with north at index 0
-            
-            Up-Down is axis 2, the third "Z" element, with the surface being index 0
+            Cardinal direction to adjust, either "east", "west", "north",
+            "south", as well as "up" or "down", or simply "u", "d", "e", "w",
+            "n", "s".
+
+            West-East is axis 0, or the first "X" element of the array, with
+            east at index -1.
+
+            North-South is axis 1, or the second "Y" element, with north at
+            index 0.
+
+            Up-Down is axis 2, the third "Z" element, with the surface being
+            index 0.
         num_layers : int, default 1
             Number of layers to add (positive number) or subtract (negative).
-            If positive, the layer values are duplicated from the outermost layer.
-        
+            If positive, the layer values are duplicated from the outermost
+            layer.
+
         Returns
         -------
         None
-        
+
         Example
         -------
-        If a grid "p_vel" originally has shape (37, 175, 70), 
-        
-        > p_vel.nudge('north',3)
-        
-        Will add three duplicated 2D layers of p_vel.array[:,0,:] to the "north" side,
-        giving the new array a shape of (37, 178, 70). 
-        2D slices p_vel.array[:,0,:] to p_vel.array[:,3,:] will be identical.
+        If a grid "p_vel" originally has shape (37, 175, 70),
+
+        > p_vel.nudge('north', 3)
+
+        Will add three duplicated 2D layers of p_vel.array[:, 0, :] to the
+        "north" side, giving the new array a shape of (37, 178, 70).
+        2D slices p_vel.array[:, 0, :] to p_vel.array[:, 3, :] will be
+        identical.
         """
         direction = direction.lower()
-        if direction[0] not in ['n','s','e','w','u','d']:
+        if direction[0] not in ['n', 's', 'e', 'w', 'u', 'd']:
             print("direction must be: up, down, east, west, north, or south")
             return
         if num_layers == 0:
@@ -1644,58 +1650,58 @@ class NLLGrid(object):
         if num_layers < 0:
             polarity = -1
         num_layers = int(np.round(num_layers))
-        
+
         for _ in range(abs(num_layers)):
-              if direction in ['east','e']:
-                  if polarity < 0:
-                      self.array = self.array[:-1,:,:]
-                  else:
-                      layer = self.array[-1,:,:]
-                      m, n = layer.shape
-                      layer = layer.reshape(1, m, n)
-                      self.array = np.concatenate((self.array, layer), axis=0)
-              elif direction in ['west','w']:
-                  if polarity < 0:
-                      self.array = self.array[1:,:,:]
-                  else:
-                      layer = self.array[0,:,:]
-                      m, n = layer.shape
-                      layer = layer.reshape(1, m, n)
-                      self.array = np.concatenate((layer, self.array), axis=0)
-              elif direction in ['south','s']:
-                  if polarity < 0:
-                      self.array = self.array[:,:-1,:]
-                  else:
-                      layer = self.array[:,-1,:]
-                      m, n = layer.shape
-                      layer = layer.reshape(m, 1, n)
-                      self.array = np.concatenate((self.array, layer), axis=1)
-              elif direction in ['north','n']:
-                  if polarity < 0:
-                      self.array = self.array[:,1:,:]
-                  else:
-                      layer = self.array[:,0,:]
-                      m, n = layer.shape
-                      layer = layer.reshape(m, 1, n)
-                      self.array = np.concatenate((layer, self.array), axis=1) 
-              elif direction in ['up','u']:
-                  if polarity < 0:
-                      self.array = self.array[:,:,1:]
-                      self.z_orig += self.dz
-                  else:
-                      layer = self.array[:,:,0]
-                      m,n = layer.shape
-                      layer = layer.reshape(m, n, 1)
-                      self.array = np.concatenate((layer,self.array), axis=2)
-                      self.z_orig -= self.dz
-              else: # down
-                  if polarity < 0:
-                      self.array = self.array[:,:,:-1]
-                  else:
-                      layer = self.array[:,:,-1]
-                      m, n = layer.shape
-                      layer = layer.reshape(m, n, 1)
-                      self.array = np.concatenate((self.array,layer), axis=2)
+            if direction in ['east', 'e']:
+                if polarity < 0:
+                    self.array = self.array[:-1, :, :]
+                else:
+                    layer = self.array[-1, :, :]
+                    m, n = layer.shape
+                    layer = layer.reshape(1, m, n)
+                    self.array = np.concatenate((self.array, layer), axis=0)
+            elif direction in ['west', 'w']:
+                if polarity < 0:
+                    self.array = self.array[1:, :, :]
+                else:
+                    layer = self.array[0, :, :]
+                    m, n = layer.shape
+                    layer = layer.reshape(1, m, n)
+                    self.array = np.concatenate((layer, self.array), axis=0)
+            elif direction in ['south', 's']:
+                if polarity < 0:
+                    self.array = self.array[:, :-1, :]
+                else:
+                    layer = self.array[:, -1, :]
+                    m, n = layer.shape
+                    layer = layer.reshape(m, 1, n)
+                    self.array = np.concatenate((self.array, layer), axis=1)
+            elif direction in ['north', 'n']:
+                if polarity < 0:
+                    self.array = self.array[:, 1:, :]
+                else:
+                    layer = self.array[:, 0, :]
+                    m, n = layer.shape
+                    layer = layer.reshape(m, 1, n)
+                    self.array = np.concatenate((layer, self.array), axis=1)
+            elif direction in ['up', 'u']:
+                if polarity < 0:
+                    self.array = self.array[:, :, 1:]
+                    self.z_orig += self.dz
+                else:
+                    layer = self.array[:, :, 0]
+                    m, n = layer.shape
+                    layer = layer.reshape(m, n, 1)
+                    self.array = np.concatenate((layer, self.array), axis=2)
+                    self.z_orig -= self.dz
+            else:  # down
+                if polarity < 0:
+                    self.array = self.array[:, :, :-1]
+                else:
+                    layer = self.array[:, :, -1]
+                    m, n = layer.shape
+                    layer = layer.reshape(m, n, 1)
+                    self.array = np.concatenate((self.array, layer), axis=2)
 
         if direction not in ['up', 'down', 'u', 'd']:
             self.horizontal_recenter()

--- a/nllgrid/NLLGrid.py
+++ b/nllgrid/NLLGrid.py
@@ -1646,9 +1646,7 @@ class NLLGrid(object):
             return
         if num_layers == 0:
             return
-        polarity = 1
-        if num_layers < 0:
-            polarity = -1
+        polarity = -1 if num_layers < 0 else 1
         num_layers = int(np.round(num_layers))
 
         for _ in range(abs(num_layers)):

--- a/nllgrid/NLLGrid.py
+++ b/nllgrid/NLLGrid.py
@@ -1599,6 +1599,108 @@ class NLLGrid(object):
         self.y_orig = -0.5 * self.ny * self.dy
         self.map_rot += angle
 
+    def nudge(self, direction, num_layers=1):
+        """
+        'Nudge' a grid's dimensions by expanding or contracting in any direction, by
+        any number of 2D layers. The output grid is also recentered.
+        
+        Parameters
+        ----------
+        direction : char
+            Cardinal direction to adjust, either "east", "west", "north", "south", 
+            as well as "up" or "down" ...or simply u, d, e, w, n, s.
+            
+            West-East is axis 0, or the first "X" element of the array, with east
+            at index -1
+            
+            North-South is axis 1, or the second "Y" element, with north at index 0
+            
+            Up-Down is axis 2, the third "Z" element, with the surface being index 0
+        num_layers : int, optional
+            Number of layers to add (positive number) or subtract (negative).
+            If positive, the layer values are duplicated from the outermost layer.
+        
+        Returns
+        -------
+        None
+        
+        Example
+        -------
+        If a grid "p_vel" originally has shape (37, 175, 70), 
+        
+        > p_vel.nudge('north',3)
+        
+        Will add three duplicated 2D layers of p_vel.array[:,0,:] to the "north" side,
+        giving the new array a shape of (37, 178, 70). 
+        2D slices p_vel.array[:,174,:] to p_vel.array[:,177,:] will be identical.
+        """
+        direction = direction.lower()
+        if direction[0] not in ['n','s','e','w','u','d']:
+            print("direction must be: up, down, east, west, north, or south")
+            return
+        if num_layers == 0:
+            return
+        polarity = 1
+        if num_layers < 0:
+            polarity = -1
+        num_layers = int(np.round(num_layers))
+        
+        for _ in range(abs(num_layers)):
+              if direction in ['east','e']:
+                  if polarity < 0:
+                      self.array = self.array[:-1,:,:]
+                  else:
+                      layer = self.array[-1,:,:]
+                      m, n = layer.shape
+                      layer = layer.reshape(1, m, n)
+                      self.array = np.concatenate((self.array, layer), axis=0)
+              elif direction in ['west','w']:
+                  if polarity < 0:
+                      self.array = self.array[1:,:,:]
+                  else:
+                      layer = self.array[0,:,:]
+                      m, n = layer.shape
+                      layer = layer.reshape(1, m, n)
+                      self.array = np.concatenate((layer, self.array), axis=0)
+              elif direction in ['south','s']:
+                  if polarity < 0:
+                      self.array = self.array[:,:-1,:]
+                  else:
+                      layer = self.array[:,-1,:]
+                      m, n = layer.shape
+                      layer = layer.reshape(m, 1, n)
+                      self.array = np.concatenate((self.array, layer), axis=1)
+              elif direction in ['north','n']:
+                  if polarity < 0:
+                      self.array = self.array[:,1:,:]
+                  else:
+                      layer = self.array[:,0,:]
+                      m, n = layer.shape
+                      layer = layer.reshape(m, 1, n)
+                      self.array = np.concatenate((layer, self.array), axis=1) 
+              elif direction in ['up','u']:
+                  if polarity < 0:
+                      self.array = self.array[:,:,1:]
+                      self.z_orig += self.dz
+                  else:
+                      layer = self.array[:,:,0]
+                      m,n = layer.shape
+                      layer = layer.reshape(m, n, 1)
+                      self.array = np.concatenate((layer,self.array), axis=2)
+                      self.z_orig -= self.dz
+              else: # down
+                  if polarity < 0:
+                      self.array = self.array[:,:,:-1]
+                  else:
+                      layer = self.array[:,:,-1]
+                      m, n = layer.shape
+                      layer = layer.reshape(m, n, 1)
+                      self.array = np.concatenate((self.array,layer), axis=2)
+
+        if direction not in ['up', 'down', 'u', 'd']:
+            self.horizontal_recenter()
+        return
+
     def copy(self):
         """
         Generate a copy of the grid.

--- a/nllgrid/NLLGrid.py
+++ b/nllgrid/NLLGrid.py
@@ -1609,8 +1609,8 @@ class NLLGrid(object):
         ----------
         direction : char
             Cardinal direction to adjust, either "east", "west", "north",
-            "south", as well as "up" or "down", or simply "u", "d", "e", "w",
-            "n", "s".
+            "south", as well as "up" or "down", or simply "e", "w", "n", "s",
+            "u", "d".
 
             West-East is axis 0, or the first "X" element of the array, with
             east at index -1.
@@ -1641,9 +1641,12 @@ class NLLGrid(object):
         identical.
         """
         direction = direction.lower()
-        if direction[0] not in ['n', 's', 'e', 'w', 'u', 'd']:
-            print("direction must be: up, down, east, west, north, or south")
-            return
+        if not direction or direction[0] not in ['e', 'w', 'n', 's', 'u', 'd']:
+            msg = (
+                'Direction must be: "east", "west", "north", "south", "up", '
+                'or "down", or simply: "e", "w", "n", "s", "u", or "d".'
+            )
+            raise ValueError(msg)
         if num_layers == 0:
             return
         polarity = -1 if num_layers < 0 else 1


### PR DESCRIPTION
Essentially what this does is allow one to add (or subtract) single (or multiple) duplicate 2D slices on any end of a 3D array. 

I often find sometimes that I need to make a grid slightly larger to fit a station in, or to make the dimensions even, or to raise it higher or deeper etc.

I have been using this and I think it works OK, but still somewhat experimental. 

original XY map view slice of a model
e.g. `plt.imshow(grd.array[:,:,0].T)`
![Figure_1](https://user-images.githubusercontent.com/22922540/218046955-c181622d-7c7a-44f7-88d7-bced1b4c2d97.png)

`grd.nudge('west',50)`
![Figure_2](https://user-images.githubusercontent.com/22922540/218047252-0c8e6438-4a28-464e-935a-c962d311ed88.png)

`grd.nudge('north',-120)`
![Figure_3](https://user-images.githubusercontent.com/22922540/218047457-84da56b8-538a-4e67-a837-41b7cc7362d4.png)


etc etc. makes use of the new `horizontal_recenter()` function as well. Let me know what you think and feel free to edit anything. 
